### PR TITLE
Send test results in background during rendering

### DIFF
--- a/jobs/Scripts/makeReport.py
+++ b/jobs/Scripts/makeReport.py
@@ -25,6 +25,13 @@ def generateJsonForReport(directory):
     for i in cfgJson:
         jsonForFormat.append("{}_original.json".format(i[4:-5]))
 
+    # FIXME: refactor report building of Core: make reports parallel with render
+    test_cases_path = os.path.join(directory, 'test_cases.json')
+    with open(test_cases_path, 'r') as cases_file:
+        cases = json.load(cases_file)
+    for case in cases:
+        case['status'] = 'done'
+
     # format values 
     for jsonReport in jsonForFormat:
         if os.path.exists(os.path.join(directory,jsonReport)):
@@ -85,6 +92,9 @@ def generateJsonForReport(directory):
                         report['tahoe_log'] = json.load(file)[0]['tahoe_log']
                     with open(os.path.join(directory, reportName.replace('_RPR', key + '_RPR')), 'w') as file:
                         json.dump([report], file, indent=4)
+
+    with open(test_cases_path, 'w') as file:
+        json.dump(cases, file, indent=4)
 
 
 def generateReport(directory):

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -90,11 +90,26 @@ def main():
         os.system('chmod +x {}'.format(os.path.abspath(args.tool)))
 
     scenes_list = []
-    try:
-        with open(os.path.join(os.path.dirname(sys.argv[0]), args.test_list)) as f:
-            scenes_list = json.load(f)
 
-        os.makedirs(os.path.join(args.output, "Color"))
+    os.makedirs(os.path.join(args.output, "Color"))
+
+    # FIXME: refactor report building of Core: make reports parallel with render
+    try:
+        test_cases_path = os.path.realpath(os.path.join(os.path.abspath(args.output), 'test_cases.json'))
+        copyfile(args.test_list, test_cases_path)
+    except Exception as e:
+        main_logger.error("Can't copy SceneList.json")
+        main_logger.error(str(e))
+        exit(-1)
+
+    try:
+        with open(test_cases_path, 'r') as file:
+            scenes_list = json.load(file)
+        for case in scenes_list:
+            if 'status' not in case:
+                case['status'] = 'active'
+        with open(test_cases_path, 'w') as file:
+            json.dump(scenes_list, file, indent=4)
         main_logger.info("Scenes to render: {}".format([name['scene'] for name in scenes_list]))
     except OSError as e:
         main_logger.error("Failed to read test cases json. ")


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1563
### PURPOSE
* Send test results in background during rendering
### EFFECT OF CHANGE
* Save dummy test_cases.json for progress monitor (It needs to be refactored as it's implemented in other tools now).
### :warning: Notes for Reviewers
* Tests can be launched by choosing 'inemankov/minio_client' as a branch of pipelines repository and 'inemankov/minio_client_dev' as a branch of tests repository
### :octocat: Related PR'S
* rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/320
* jobs_launcher: https://github.com/luxteam/jobs_launcher/pull/92
* jobs_test_rprviewer: https://github.com/luxteam/jobs_test_rprviewer/pull/53
### Jenkins Builds
* Blender: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/2880/
* Maya: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/3874/
* Max: https://rpr.cis.luxoft.com/job/RadeonProRenderMaxPluginManual/1060/
* Core: https://rpr.cis.luxoft.com/job/RadeonProRenderCoreManual/783/
* RPRViewer: https://rpr.cis.luxoft.com/job/RadeonProViewerManual/893/